### PR TITLE
feat(边缘网关): 添加https域名映射配置

### DIFF
--- a/src/main/java/org/jetlinks/pro/edge/frp/server/DefaultFrpServerManager.java
+++ b/src/main/java/org/jetlinks/pro/edge/frp/server/DefaultFrpServerManager.java
@@ -92,6 +92,9 @@ public class DefaultFrpServerManager implements FrpServerManager, CommandLineRun
                     FrpClientConfig clientConfig = new FrpClientConfig();
                     clientConfig.setType(FrpDistributeInfo.FrpcType.of(request.getTransport().name()));
                     clientConfig.setRemotePort(port);
+                    if (distributeInfo.getDomainMapping() != null) {
+                        clientConfig.setDomain(distributeInfo.getDomainMapping().get(port));
+                    }
                     distributeInfo.setClientConfigList(Collections.singletonList(clientConfig));
                 })
             );
@@ -119,7 +122,7 @@ public class DefaultFrpServerManager implements FrpServerManager, CommandLineRun
                         distributedResource.values().forEach(res -> {
                             if (res.containsPort(request.getTransport(), port)) {
                                 // 端口已被使用
-                                throw new BusinessException("error.frp_port_used", port);
+                                throw new BusinessException("error.frp_port_used", 500, port);
                             }
                         });
                         NetworkResource res = new NetworkResource();

--- a/src/main/java/org/jetlinks/pro/edge/frp/server/FrpServerConfig.java
+++ b/src/main/java/org/jetlinks/pro/edge/frp/server/FrpServerConfig.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * frp服务配置.
@@ -56,6 +57,8 @@ public class FrpServerConfig {
      * 网络资源配置，支持[起始端口-终止端口/协议]的格式（例如8811-8820/tcp）
      */
     private List<String> resources = new ArrayList<>();
+
+    private Map<Integer, String> domainMapping;
 
     public void validate() {
         ValidatorUtils.tryValidate(this);


### PR DESCRIPTION
由于浏览器禁止https跳转http，添加了端口与域名url的映射。
服务端分配端口后，浏览器可直接使用映射的https域名访问